### PR TITLE
Fix timer from 'finishing' while inactive

### DIFF
--- a/meditation-app/src/pages/Home.tsx
+++ b/meditation-app/src/pages/Home.tsx
@@ -64,7 +64,7 @@ const Timer: React.FC = () => {
         setCircleDasharray();
         setRemainingPathColor(getRemainingPathColor(timeLeft));
       }, 1000);
-    } else if (timeLeft === 0) {
+    } else if (isActive && timeLeft === 0) {
       if (timerInterval) clearInterval(timerInterval); // Only clear if not null
       setIsActive(false);
       setShowMessage(true); // Show the message when timer ends


### PR DESCRIPTION
If the user "clears" the timer (highlights with ctrl+a and backspaces), then it sets the timer to 0, which tricks the timer into thinking it "finished" and shows the message, even though the timer is inactive.